### PR TITLE
Feat/actions stop

### DIFF
--- a/SpaceBattle.Lib.Tests/ActionStopIoCTest.cs
+++ b/SpaceBattle.Lib.Tests/ActionStopIoCTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class ActionsStopIoCTests
+{
+    public ActionsStopIoCTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var iocScope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_ShouldRegisterStopCommandDependency()
+    {
+        var mockInjectable = new Mock<ICommandInjectable>();
+
+        var gameObject = new Dictionary<string, object>
+        {
+            ["repeatableMove"] = mockInjectable.Object
+        };
+        Hwdtech.ICommand injected = null;
+        mockInjectable.Setup(x => x.Inject(It.IsAny<Hwdtech.ICommand>())).Callback<Hwdtech.ICommand>(c => injected = c);
+
+        new RegisterIoCDependencyActionsStop().Execute();
+
+        var order = new Dictionary<string, object>
+        {
+            ["gameObject"] = gameObject,
+            ["cmdType"] = "Move"
+        };
+
+        var cmd = IoC.Resolve<Hwdtech.ICommand>("Actions.Stop", order);
+
+        cmd.Execute();
+        Assert.NotNull(cmd);
+
+        Assert.NotNull(injected);
+        injected.Execute();
+
+        mockInjectable.Verify(x => x.Inject(It.IsAny<Hwdtech.ICommand>()), Times.Once);
+    }
+}

--- a/SpaceBattle.Lib/EmptyCommand.cs
+++ b/SpaceBattle.Lib/EmptyCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace StarWars.Lib;
+
+public class EmptyCommand : Hwdtech.ICommand
+{
+    public void Execute() { }
+}

--- a/SpaceBattle.Lib/RegisterIoCDependencyActionsStop.cs
+++ b/SpaceBattle.Lib/RegisterIoCDependencyActionsStop.cs
@@ -1,0 +1,18 @@
+﻿using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class RegisterIoCDependencyActionsStop : Hwdtech.ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Actions.Stop", (object[] args) =>
+        {
+            var order = (IDictionary<string, object>)args[0];
+
+            return new StopCommand(
+                (IDictionary<string, object>)order["gameObject"],
+                (string)order["cmdType"]);
+        }).Execute();
+    }
+}

--- a/SpaceBattle.Lib/StopCommand.cs
+++ b/SpaceBattle.Lib/StopCommand.cs
@@ -1,0 +1,17 @@
+﻿namespace StarWars.Lib;
+
+public class StopCommand : Hwdtech.ICommand
+{
+    private readonly IDictionary<string, object> _gameObject;
+    private readonly string _cmdType;
+    public StopCommand(IDictionary<string, object> gameObject, string commandType)
+    {
+        _gameObject = gameObject;
+        _cmdType = commandType;
+    }
+    public void Execute()
+    {
+        var injectable = (ICommandInjectable)_gameObject[$"repeatable{_cmdType}"];
+        injectable.Inject(new EmptyCommand());
+    }
+}


### PR DESCRIPTION
Определить зависимость "Actions.Stop" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:
IDictionary<string, object> order = ...; // приказ об остановке длительной операции
Ioc.Resolve("Actions.Stop", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStop

public class RegisterIoCDependencyActionsStop : ICommand
{
public void Execute()
{
// здесь код для регистрации зависимостей
}
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStop зависимость разрешается.
Остановка команды выполняется за константное время.

Выполнил: Харлов Никита