### PR TITLE
Feat/CommandInjectableCommand

### DIFF
--- a/SpaceBattle.Lib.Tests/InjectableCommandTests.cs
+++ b/SpaceBattle.Lib.Tests/InjectableCommandTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Hwdtech;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Tests
+{
+    public class CommandInjectableCommandTests
+    {
+        [Fact]
+        public void Execute_InjectedCommand_ExecutesInjectedCommand()
+        {
+            var mockCommand = new Mock<Hwdtech.ICommand>();
+            mockCommand.Setup(x => x.Execute()).Verifiable();
+            var commandInjectableCommand = new CommandInjectableCommand();
+            commandInjectableCommand.Inject(mockCommand.Object);
+
+            commandInjectableCommand.Execute();
+
+            mockCommand.Verify();
+        }
+
+        [Fact]
+        public void Execute_NoInjectedCommand_ThrowsException()
+        {
+            var commandInjectableCommand = new CommandInjectableCommand();
+
+            Assert.Throws<InvalidOperationException>(() => commandInjectableCommand.Execute());
+        }
+    }
+}

--- a/SpaceBattle.Lib.Tests/InjectableCommandTests.cs
+++ b/SpaceBattle.Lib.Tests/InjectableCommandTests.cs
@@ -1,5 +1,4 @@
-using System;
-using Hwdtech;
+﻿using System;
 using Moq;
 using StarWars.Lib;
 using Xunit;

--- a/SpaceBattle.Lib/InjectableCommand.cs
+++ b/SpaceBattle.Lib/InjectableCommand.cs
@@ -1,0 +1,25 @@
+using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class CommandInjectableCommand : ICommand, ICommandInjectable
+{
+    private Hwdtech.ICommand? _injectedCommand;
+
+    public CommandInjectableCommand() { }
+
+    public void Inject(Hwdtech.ICommand command)
+    {
+        _injectedCommand = command;
+    }
+
+    public void Execute()
+    {
+        if (_injectedCommand == null)
+        {
+            throw new InvalidOperationException("Command not injected.");
+        }
+
+        _injectedCommand.Execute();
+    }
+}

--- a/SpaceBattle.Lib/InjectableCommand.cs
+++ b/SpaceBattle.Lib/InjectableCommand.cs
@@ -1,6 +1,4 @@
-using Hwdtech;
-
-namespace StarWars.Lib;
+﻿namespace StarWars.Lib;
 
 public class CommandInjectableCommand : ICommand, ICommandInjectable
 {


### PR DESCRIPTION
17. Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.

Критерии приемки:
Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.