### PR TITLE
Feat/register macro command

### DIFF
--- a/SpaceBattle.Lib.Tests/MacroCommandTest.cs
+++ b/SpaceBattle.Lib.Tests/MacroCommandTest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class MacroCommandTests
+{
+    [Fact]
+    public void MacroCommand_ExecutesAllCommandsFromArray()
+    {
+        var mock1 = new Mock<Hwdtech.ICommand>();
+        var mock2 = new Mock<Hwdtech.ICommand>();
+        var mock3 = new Mock<Hwdtech.ICommand>();
+
+        var macro = new MacroCommand(new List<Hwdtech.ICommand> { mock1.Object, mock2.Object, mock3.Object });
+        macro.Execute();
+
+        mock1.Verify(c => c.Execute(), Times.Once);
+        mock2.Verify(c => c.Execute(), Times.Once);
+        mock3.Verify(c => c.Execute(), Times.Once);
+    }
+
+    [Fact]
+    public void MacroCommand_WhenCommandThrows_PropagatesExceptionAndSkipsRemainingCommands()
+    {
+        var mock1 = new Mock<Hwdtech.ICommand>();
+        var mock2 = new Mock<Hwdtech.ICommand>();
+        var mock3 = new Mock<Hwdtech.ICommand>();
+
+        mock2.Setup(c => c.Execute()).Throws<Exception>();
+
+        var macro = new MacroCommand(new List<Hwdtech.ICommand> { mock1.Object, mock2.Object, mock3.Object });
+
+        Assert.Throws<Exception>(() => macro.Execute());
+        mock1.Verify(c => c.Execute(), Times.Once);
+        mock3.Verify(c => c.Execute(), Times.Never);
+    }
+}

--- a/SpaceBattle.Lib.Tests/MacroCommandTest.cs
+++ b/SpaceBattle.Lib.Tests/MacroCommandTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Moq;
 using StarWars.Lib;

--- a/SpaceBattle.Lib.Tests/RegisterMacroCommandIoCTest.cs
+++ b/SpaceBattle.Lib.Tests/RegisterMacroCommandIoCTest.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class RegisterMacroCommandIoCTests
+{
+    public RegisterMacroCommandIoCTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var iocScope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_ShouldRegisterMacroCommandDependency()
+    {
+        var mockCmd1 = new Mock<Hwdtech.ICommand>();
+        var mockCmd2 = new Mock<Hwdtech.ICommand>();
+
+        new RegisterIoCDependencyMacroCommand().Execute();
+
+        var commands = new List<Hwdtech.ICommand> { mockCmd1.Object, mockCmd2.Object };
+        var macroCommand = IoC.Resolve<Hwdtech.ICommand>("Commands.Macro", commands);
+
+        Assert.NotNull(macroCommand);
+        Assert.IsType<MacroCommand>(macroCommand);
+    }
+}

--- a/SpaceBattle.Lib.Tests/RegisterMacroCommandIoCTest.cs
+++ b/SpaceBattle.Lib.Tests/RegisterMacroCommandIoCTest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Hwdtech;
 using Hwdtech.Ioc;
 using Moq;

--- a/SpaceBattle.Lib/MacroCommand.cs
+++ b/SpaceBattle.Lib/MacroCommand.cs
@@ -1,4 +1,4 @@
-namespace StarWars.Lib;
+﻿namespace StarWars.Lib;
 
 public class MacroCommand : Hwdtech.ICommand
 {

--- a/SpaceBattle.Lib/MacroCommand.cs
+++ b/SpaceBattle.Lib/MacroCommand.cs
@@ -1,0 +1,27 @@
+namespace StarWars.Lib;
+
+public class MacroCommand : Hwdtech.ICommand
+{
+    private readonly IReadOnlyList<Hwdtech.ICommand> _commands;
+
+    public MacroCommand(IEnumerable<Hwdtech.ICommand> commands)
+    {
+        _commands = commands.ToList();
+    }
+
+    public void Execute()
+    {
+        ExecuteFrom(0);
+    }
+
+    private void ExecuteFrom(int index)
+    {
+        if (index >= _commands.Count)
+        {
+            return;
+        }
+
+        _commands[index].Execute();
+        ExecuteFrom(index + 1);
+    }
+}

--- a/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
+++ b/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
@@ -7,6 +7,6 @@ public class RegisterIoCDependencyMacroCommand : ICommand
     public void Execute()
     {
         IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.Macro",
-            (Func<object, object>)(obj => new MacroCommand((IEnumerable<Hwdtech.ICommand>)obj))).Execute();
+            (Func<object[], object>)(args => new MacroCommand((IEnumerable<Hwdtech.ICommand>)args[0]))).Execute();
     }
 }

--- a/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
+++ b/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
@@ -1,4 +1,4 @@
-using Hwdtech;
+﻿using Hwdtech;
 
 namespace StarWars.Lib;
 

--- a/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
+++ b/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
@@ -1,0 +1,12 @@
+using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class RegisterIoCDependencyMacroCommand : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.Macro",
+            (Func<object, object>)(obj => new MacroCommand((IEnumerable<Hwdtech.ICommand>)obj))).Execute();
+    }
+}


### PR DESCRIPTION
Определить зависимость "Commands.Macro" в IoC, которая по массиву команд возвращает Макрокоманду.
Указание: Для регистрации зависимости определить команду RegisterIoCDependencyMacroCommand:
public class RegisterIoCDependencyMacroCommand : ICommand
{
public void Execute()
{
// код, регистрирующий зависимость
}
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencyMacroCommand зависимость разрешается.