### PR TITLE
feat: add ShootCommand, Game, authorization and game object repository

### DIFF
--- a/SpaceBattle.Lib.Tests/CheckAuthorizationCommandTest.cs
+++ b/SpaceBattle.Lib.Tests/CheckAuthorizationCommandTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class CheckAuthorizationCommandTest
+{
+    [Fact]
+    public void Execute_AuthorizedPlayer_DoesNotThrow()
+    {
+        var mockAuth = new Mock<IAuthorizationService>();
+        mockAuth.Setup(x => x.IsAuthorized("game1", "ship1", "player1")).Returns(true);
+
+        var cmd = new CheckAuthorizationCommand(mockAuth.Object, "game1", "ship1", "player1");
+
+        cmd.Execute();
+
+        mockAuth.Verify(x => x.IsAuthorized("game1", "ship1", "player1"), Times.Once);
+    }
+
+    [Fact]
+    public void Execute_UnauthorizedPlayer_ThrowsUnauthorizedAccessException()
+    {
+        var mockAuth = new Mock<IAuthorizationService>();
+        mockAuth.Setup(x => x.IsAuthorized("game1", "ship1", "hacker")).Returns(false);
+
+        var cmd = new CheckAuthorizationCommand(mockAuth.Object, "game1", "ship1", "hacker");
+
+        Assert.Throws<UnauthorizedAccessException>(() => cmd.Execute());
+    }
+
+    [Fact]
+    public void Execute_AuthServiceThrows_Propagates()
+    {
+        var mockAuth = new Mock<IAuthorizationService>();
+        mockAuth.Setup(x => x.IsAuthorized(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws<InvalidOperationException>();
+
+        var cmd = new CheckAuthorizationCommand(mockAuth.Object, "g", "o", "p");
+
+        Assert.Throws<InvalidOperationException>(() => cmd.Execute());
+    }
+}

--- a/SpaceBattle.Lib.Tests/CheckAuthorizationIoCTest.cs
+++ b/SpaceBattle.Lib.Tests/CheckAuthorizationIoCTest.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class CheckAuthorizationIoCTest
+{
+    public CheckAuthorizationIoCTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var scope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", scope).Execute();
+    }
+
+    [Fact]
+    public void Execute_ShouldRegisterCheckAuthorizationDependency()
+    {
+        var mockAuth = new Mock<IAuthorizationService>();
+        mockAuth.Setup(x => x.IsAuthorized("game1", "ship1", "player1")).Returns(true);
+
+        new RegisterIoCDependencyCheckAuthorization().Execute();
+
+        var order = new Dictionary<string, object>
+        {
+            ["authService"] = mockAuth.Object,
+            ["gameId"] = "game1",
+            ["objectId"] = "ship1",
+            ["playerId"] = "player1"
+        };
+
+        var cmd = IoC.Resolve<Hwdtech.ICommand>("Commands.CheckAuthorization", order);
+
+        Assert.NotNull(cmd);
+        Assert.IsType<CheckAuthorizationCommand>(cmd);
+
+        cmd.Execute();
+
+        mockAuth.Verify(x => x.IsAuthorized("game1", "ship1", "player1"), Times.Once);
+    }
+
+    [Fact]
+    public void Execute_UnauthorizedPlayer_ThrowsFromResolvedCommand()
+    {
+        var mockAuth = new Mock<IAuthorizationService>();
+        mockAuth.Setup(x => x.IsAuthorized(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(false);
+
+        new RegisterIoCDependencyCheckAuthorization().Execute();
+
+        var order = new Dictionary<string, object>
+        {
+            ["authService"] = mockAuth.Object,
+            ["gameId"] = "game1",
+            ["objectId"] = "ship1",
+            ["playerId"] = "hacker"
+        };
+
+        var cmd = IoC.Resolve<Hwdtech.ICommand>("Commands.CheckAuthorization", order);
+
+        Assert.Throws<UnauthorizedAccessException>(() => cmd.Execute());
+    }
+}

--- a/SpaceBattle.Lib.Tests/GameObjectRepositoryTest.cs
+++ b/SpaceBattle.Lib.Tests/GameObjectRepositoryTest.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class GameObjectRepositoryTest
+{
+    private readonly GameObjectRepository _repository = new();
+
+    [Fact]
+    public void Add_ThenGetById_ReturnsAddedObject()
+    {
+        var obj = new Dictionary<string, object> { ["x"] = 42 };
+
+        _repository.Add("obj1", obj);
+
+        Assert.Equal(obj, _repository.GetById("obj1"));
+    }
+
+    [Fact]
+    public void GetById_NotFound_ThrowsKeyNotFoundException()
+    {
+        Assert.Throws<KeyNotFoundException>(() => _repository.GetById("nonexistent"));
+    }
+
+    [Fact]
+    public void Contains_ExistingId_ReturnsTrue()
+    {
+        _repository.Add("obj1", new Dictionary<string, object>());
+
+        Assert.True(_repository.Contains("obj1"));
+    }
+
+    [Fact]
+    public void Contains_NonExistingId_ReturnsFalse()
+    {
+        Assert.False(_repository.Contains("nonexistent"));
+    }
+
+    [Fact]
+    public void Add_OverwritesExistingObject()
+    {
+        var first = new Dictionary<string, object> { ["v"] = 1 };
+        var second = new Dictionary<string, object> { ["v"] = 2 };
+
+        _repository.Add("id", first);
+        _repository.Add("id", second);
+
+        Assert.Equal(second, _repository.GetById("id"));
+    }
+}

--- a/SpaceBattle.Lib.Tests/GameTest.cs
+++ b/SpaceBattle.Lib.Tests/GameTest.cs
@@ -59,6 +59,4 @@ public class GameTest
 
         Assert.Equal([1, 2], executionOrder);
     }
-
-
 }

--- a/SpaceBattle.Lib.Tests/GameTest.cs
+++ b/SpaceBattle.Lib.Tests/GameTest.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class GameTest
+{
+    private readonly Game _game = new();
+
+    [Fact]
+    public void Update_ExecutesCommandFromQueue()
+    {
+        var mockCmd = new Mock<Hwdtech.ICommand>();
+        _game.Receive(mockCmd.Object);
+
+        _game.Update();
+
+        mockCmd.Verify(x => x.Execute(), Times.Once);
+    }
+
+    [Fact]
+    public void Update_EmptyQueue_DoesNotThrow()
+    {
+        _game.Update();
+    }
+
+    [Fact]
+    public void Update_MultipleCommands_ExecutesOnePerCall()
+    {
+        var mockCmd1 = new Mock<Hwdtech.ICommand>();
+        var mockCmd2 = new Mock<Hwdtech.ICommand>();
+
+        _game.Receive(mockCmd1.Object);
+        _game.Receive(mockCmd2.Object);
+
+        _game.Update();
+
+        mockCmd1.Verify(x => x.Execute(), Times.Once);
+        mockCmd2.Verify(x => x.Execute(), Times.Never);
+    }
+
+    [Fact]
+    public void Update_ExecutesCommandsInFifoOrder()
+    {
+        var executionOrder = new List<int>();
+        var mockCmd1 = new Mock<Hwdtech.ICommand>();
+        var mockCmd2 = new Mock<Hwdtech.ICommand>();
+
+        mockCmd1.Setup(x => x.Execute()).Callback(() => executionOrder.Add(1));
+        mockCmd2.Setup(x => x.Execute()).Callback(() => executionOrder.Add(2));
+
+        _game.Receive(mockCmd1.Object);
+        _game.Receive(mockCmd2.Object);
+
+        _game.Update();
+        _game.Update();
+
+        Assert.Equal([1, 2], executionOrder);
+    }
+
+
+}

--- a/SpaceBattle.Lib.Tests/ShootCommandIoCTest.cs
+++ b/SpaceBattle.Lib.Tests/ShootCommandIoCTest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class ShootCommandIoCTest
+{
+    public ShootCommandIoCTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var scope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", scope).Execute();
+    }
+
+    [Fact]
+    public void Execute_ShouldRegisterShootCommandDependency()
+    {
+        var mockShootable = new Mock<IShootable>();
+        var mockRepo = new Mock<IGameObjectRepository>();
+        var mockQueue = new Mock<ICommandReceiver>();
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Adapters.IShootable",
+            (Func<object, object>)(obj => mockShootable.Object)).Execute();
+
+        new RegisterIoCDependencyShootCommand().Execute();
+
+        var order = new Dictionary<string, object>
+        {
+            ["gameObject"] = new Dictionary<string, object>(),
+            ["repository"] = mockRepo.Object,
+            ["queue"] = mockQueue.Object
+        };
+
+        var cmd = IoC.Resolve<StarWars.Lib.ICommand>("Commands.Shoot", order);
+
+        Assert.NotNull(cmd);
+        Assert.IsType<ShootCommand>(cmd);
+    }
+}

--- a/SpaceBattle.Lib.Tests/ShootCommandTest.cs
+++ b/SpaceBattle.Lib.Tests/ShootCommandTest.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Moq;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Test;
+
+public class ShootCommandTest
+{
+    public ShootCommandTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var scope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", scope).Execute();
+    }
+
+    private static (Mock<IShootable>, Mock<IGameObjectRepository>, Mock<ICommandReceiver>, Mock<Hwdtech.ICommand>) SetupMocks()
+    {
+        return (new Mock<IShootable>(), new Mock<IGameObjectRepository>(), new Mock<ICommandReceiver>(), new Mock<Hwdtech.ICommand>());
+    }
+
+    [Fact]
+    public void Execute_AddsTorpedoToRepository()
+    {
+        var (mockShootable, mockRepo, mockQueue, mockStartCmd) = SetupMocks();
+        mockShootable.Setup(x => x.GetPosition()).Returns(new Vector([10, 20]));
+        mockShootable.Setup(x => x.GetVelocity()).Returns(new Vector([1, 0]));
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Actions.Start",
+            (Func<object[], object>)(args => mockStartCmd.Object)).Execute();
+
+        new ShootCommand(mockShootable.Object, mockRepo.Object, mockQueue.Object).Execute();
+
+        mockRepo.Verify(x => x.Add(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void Execute_StartsMovingTorpedo()
+    {
+        var (mockShootable, mockRepo, mockQueue, mockStartCmd) = SetupMocks();
+        mockShootable.Setup(x => x.GetPosition()).Returns(new Vector([10, 20]));
+        mockShootable.Setup(x => x.GetVelocity()).Returns(new Vector([1, 0]));
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Actions.Start",
+            (Func<object[], object>)(args => mockStartCmd.Object)).Execute();
+
+        new ShootCommand(mockShootable.Object, mockRepo.Object, mockQueue.Object).Execute();
+
+        mockStartCmd.Verify(x => x.Execute(), Times.Once);
+    }
+
+    [Fact]
+    public void Execute_TorpedoHasSpacecraftPositionAndVelocity()
+    {
+        var position = new Vector([5, 7]);
+        var velocity = new Vector([2, -1]);
+
+        var (mockShootable, mockRepo, mockQueue, mockStartCmd) = SetupMocks();
+        mockShootable.Setup(x => x.GetPosition()).Returns(position);
+        mockShootable.Setup(x => x.GetVelocity()).Returns(velocity);
+
+        IDictionary<string, object> capturedTorpedo = null;
+        mockRepo.Setup(x => x.Add(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()))
+            .Callback<string, IDictionary<string, object>>((_, obj) => capturedTorpedo = obj);
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Actions.Start",
+            (Func<object[], object>)(args => mockStartCmd.Object)).Execute();
+
+        new ShootCommand(mockShootable.Object, mockRepo.Object, mockQueue.Object).Execute();
+
+        Assert.NotNull(capturedTorpedo);
+        Assert.Equal(position, capturedTorpedo["position"]);
+        Assert.Equal(velocity, capturedTorpedo["velocity"]);
+    }
+
+    [Fact]
+    public void Execute_GetPositionThrows_Propagates()
+    {
+        var (mockShootable, mockRepo, mockQueue, _) = SetupMocks();
+        mockShootable.Setup(x => x.GetPosition()).Throws<InvalidOperationException>();
+
+        Assert.Throws<InvalidOperationException>(
+            () => new ShootCommand(mockShootable.Object, mockRepo.Object, mockQueue.Object).Execute());
+    }
+
+    [Fact]
+    public void Execute_GetVelocityThrows_Propagates()
+    {
+        var (mockShootable, mockRepo, mockQueue, _) = SetupMocks();
+        mockShootable.Setup(x => x.GetPosition()).Returns(new Vector([0, 0]));
+        mockShootable.Setup(x => x.GetVelocity()).Throws<InvalidOperationException>();
+
+        Assert.Throws<InvalidOperationException>(
+            () => new ShootCommand(mockShootable.Object, mockRepo.Object, mockQueue.Object).Execute());
+    }
+}

--- a/SpaceBattle.Lib/CheckAuthorizationCommand.cs
+++ b/SpaceBattle.Lib/CheckAuthorizationCommand.cs
@@ -1,0 +1,26 @@
+﻿namespace StarWars.Lib;
+
+public class CheckAuthorizationCommand : Hwdtech.ICommand
+{
+    private readonly IAuthorizationService _authService;
+    private readonly string _gameId;
+    private readonly string _objectId;
+    private readonly string _playerId;
+
+    public CheckAuthorizationCommand(IAuthorizationService authService, string gameId, string objectId, string playerId)
+    {
+        _authService = authService;
+        _gameId = gameId;
+        _objectId = objectId;
+        _playerId = playerId;
+    }
+
+    public void Execute()
+    {
+        if (!_authService.IsAuthorized(_gameId, _objectId, _playerId))
+        {
+            throw new UnauthorizedAccessException(
+                $"Player '{_playerId}' is not authorized to act on object '{_objectId}' in game '{_gameId}'.");
+        }
+    }
+}

--- a/SpaceBattle.Lib/Game.cs
+++ b/SpaceBattle.Lib/Game.cs
@@ -1,0 +1,16 @@
+﻿namespace StarWars.Lib;
+
+public class Game : ICommandReceiver
+{
+    private readonly Queue<Hwdtech.ICommand> _commandQueue = new();
+
+    public void Receive(Hwdtech.ICommand cmd) => _commandQueue.Enqueue(cmd);
+
+    public void Update()
+    {
+        if (_commandQueue.Count > 0)
+        {
+            _commandQueue.Dequeue().Execute();
+        }
+    }
+}

--- a/SpaceBattle.Lib/GameObjectRepository.cs
+++ b/SpaceBattle.Lib/GameObjectRepository.cs
@@ -1,0 +1,12 @@
+﻿namespace StarWars.Lib;
+
+public class GameObjectRepository : IGameObjectRepository
+{
+    private readonly Dictionary<string, IDictionary<string, object>> _objects = new();
+
+    public IDictionary<string, object> GetById(string id) => _objects[id];
+
+    public void Add(string id, IDictionary<string, object> gameObject) => _objects[id] = gameObject;
+
+    public bool Contains(string id) => _objects.ContainsKey(id);
+}

--- a/SpaceBattle.Lib/IAuthorizationService.cs
+++ b/SpaceBattle.Lib/IAuthorizationService.cs
@@ -1,0 +1,6 @@
+﻿namespace StarWars.Lib;
+
+public interface IAuthorizationService
+{
+    bool IsAuthorized(string gameId, string objectId, string playerId);
+}

--- a/SpaceBattle.Lib/IGameObjectRepository.cs
+++ b/SpaceBattle.Lib/IGameObjectRepository.cs
@@ -1,0 +1,8 @@
+﻿namespace StarWars.Lib;
+
+public interface IGameObjectRepository
+{
+    IDictionary<string, object> GetById(string id);
+    void Add(string id, IDictionary<string, object> gameObject);
+    bool Contains(string id);
+}

--- a/SpaceBattle.Lib/IShootable.cs
+++ b/SpaceBattle.Lib/IShootable.cs
@@ -1,0 +1,7 @@
+﻿namespace StarWars.Lib;
+
+public interface IShootable
+{
+    Vector GetPosition();
+    Vector GetVelocity();
+}

--- a/SpaceBattle.Lib/RegisterIoCDependencyCheckAuthorization.cs
+++ b/SpaceBattle.Lib/RegisterIoCDependencyCheckAuthorization.cs
@@ -1,0 +1,20 @@
+﻿using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class RegisterIoCDependencyCheckAuthorization : Hwdtech.ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.CheckAuthorization",
+            (Func<object[], object>)(args =>
+            {
+                var order = (IDictionary<string, object>)args[0];
+                return new CheckAuthorizationCommand(
+                    (IAuthorizationService)order["authService"],
+                    (string)order["gameId"],
+                    (string)order["objectId"],
+                    (string)order["playerId"]);
+            })).Execute();
+    }
+}

--- a/SpaceBattle.Lib/RegisterIoCDependencyShootCommand.cs
+++ b/SpaceBattle.Lib/RegisterIoCDependencyShootCommand.cs
@@ -1,0 +1,19 @@
+﻿using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class RegisterIoCDependencyShootCommand : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.Shoot",
+            (Func<object[], object>)(args =>
+            {
+                var order = (IDictionary<string, object>)args[0];
+                return new ShootCommand(
+                    IoC.Resolve<IShootable>("Adapters.IShootable", order["gameObject"]),
+                    (IGameObjectRepository)order["repository"],
+                    (ICommandReceiver)order["queue"]);
+            })).Execute();
+    }
+}

--- a/SpaceBattle.Lib/ShootCommand.cs
+++ b/SpaceBattle.Lib/ShootCommand.cs
@@ -1,0 +1,36 @@
+﻿using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class ShootCommand : ICommand
+{
+    private readonly IShootable _spacecraft;
+    private readonly IGameObjectRepository _repository;
+    private readonly ICommandReceiver _queue;
+
+    public ShootCommand(IShootable spacecraft, IGameObjectRepository repository, ICommandReceiver queue)
+    {
+        _spacecraft = spacecraft;
+        _repository = repository;
+        _queue = queue;
+    }
+
+    public void Execute()
+    {
+        var torpedoId = Guid.NewGuid().ToString();
+        var torpedo = new Dictionary<string, object>
+        {
+            ["position"] = _spacecraft.GetPosition(),
+            ["velocity"] = _spacecraft.GetVelocity()
+        };
+
+        _repository.Add(torpedoId, torpedo);
+
+        IoC.Resolve<Hwdtech.ICommand>("Actions.Start", new Dictionary<string, object>
+        {
+            ["gameObject"] = torpedo,
+            ["queue"] = _queue,
+            ["cmdType"] = "Move"
+        }).Execute();
+    }
+}


### PR DESCRIPTION
- IGameObjectRepository / GameObjectRepository — репозиторий игровых объектов
- IShootable / ShootCommand — команда выстрела: создаёт торпеду, регистрирует в репозитории, запускает движение через Actions.Start
- RegisterIoCDependencyShootCommand — регистрация Commands.Shoot в IoC
- Game — класс игры, реализует ICommandReceiver, хранит очередь команд, Update() выполняет по одной
- IAuthorizationService / CheckAuthorizationCommand — проверка авторизации игрока
- RegisterIoCDependencyCheckAuthorization — регистрация Commands.CheckAuthorization в IoC