### PR TITLE
Feat/register adapter dependency

### DIFF
--- a/SpaceBattle.Lib.Tests/DictionaryAdapterTests.cs
+++ b/SpaceBattle.Lib.Tests/DictionaryAdapterTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using StarWars.Lib;
+using Xunit;
+
+namespace StarWars.Tests;
+
+public interface IMovingObject
+{
+    Vector Location { get; set; }
+    Vector Velocity { get; }
+}
+
+public static class VelocityResolver
+{
+    public static object Resolve(IDictionary<string, object> dict) =>
+        dict["vel"];
+}
+
+public class DictionaryAdapterTests
+{
+    private static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> NoStrategies =
+        new Dictionary<string, Func<IDictionary<string, object>, object>>();
+
+    [Fact]
+    public void Get_ReadsPropertyFromDictionary()
+    {
+        var location = new Vector([1, 2]);
+        var dict = new Dictionary<string, object> { ["Location"] = location, ["Velocity"] = new Vector([0, 0]) };
+
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies);
+
+        Assert.Equal(location, adapter.Location);
+    }
+
+    [Fact]
+    public void Set_WritesPropertyToDictionary()
+    {
+        var dict = new Dictionary<string, object> { ["Location"] = new Vector([0, 0]), ["Velocity"] = new Vector([0, 0]) };
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies);
+        var newLocation = new Vector([5, 5]);
+
+        adapter.Location = newLocation;
+
+        Assert.Equal(newLocation, dict["Location"]);
+    }
+
+    [Fact]
+    public void Get_UsesCustomStrategyWhenProvided()
+    {
+        var velocity = new Vector([3, 4]);
+        var dict = new Dictionary<string, object> { ["Location"] = new Vector([0, 0]), ["vel"] = velocity };
+        var strategies = new Dictionary<string, Func<IDictionary<string, object>, object>>
+        {
+            ["Velocity"] = VelocityResolver.Resolve
+        };
+
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, strategies);
+
+        Assert.Equal(velocity, adapter.Velocity);
+    }
+
+    [Fact]
+    public void Get_ThrowsWhenKeyMissingAndNoStrategy()
+    {
+        var dict = new Dictionary<string, object>();
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies);
+
+        Assert.Throws<KeyNotFoundException>(() => adapter.Velocity);
+    }
+}

--- a/SpaceBattle.Lib.Tests/DictionaryAdapterTests.cs
+++ b/SpaceBattle.Lib.Tests/DictionaryAdapterTests.cs
@@ -19,6 +19,9 @@ public static class VelocityResolver
 
 public class DictionaryAdapterTests
 {
+    private static readonly IReadOnlyList<IMethodHandler> DefaultHandlers =
+        [new GetterMethodHandler(), new SetterMethodHandler()];
+
     private static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> NoStrategies =
         new Dictionary<string, Func<IDictionary<string, object>, object>>();
 
@@ -28,7 +31,7 @@ public class DictionaryAdapterTests
         var location = new Vector([1, 2]);
         var dict = new Dictionary<string, object> { ["Location"] = location, ["Velocity"] = new Vector([0, 0]) };
 
-        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies);
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies, DefaultHandlers);
 
         Assert.Equal(location, adapter.Location);
     }
@@ -37,7 +40,7 @@ public class DictionaryAdapterTests
     public void Set_WritesPropertyToDictionary()
     {
         var dict = new Dictionary<string, object> { ["Location"] = new Vector([0, 0]), ["Velocity"] = new Vector([0, 0]) };
-        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies);
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies, DefaultHandlers);
         var newLocation = new Vector([5, 5]);
 
         adapter.Location = newLocation;
@@ -55,7 +58,7 @@ public class DictionaryAdapterTests
             ["Velocity"] = VelocityResolver.Resolve
         };
 
-        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, strategies);
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, strategies, DefaultHandlers);
 
         Assert.Equal(velocity, adapter.Velocity);
     }
@@ -64,8 +67,17 @@ public class DictionaryAdapterTests
     public void Get_ThrowsWhenKeyMissingAndNoStrategy()
     {
         var dict = new Dictionary<string, object>();
-        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies);
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies, DefaultHandlers);
 
         Assert.Throws<KeyNotFoundException>(() => adapter.Velocity);
+    }
+
+    [Fact]
+    public void Invoke_ThrowsWhenNoHandlerRegistered()
+    {
+        var dict = new Dictionary<string, object>();
+        var adapter = DictionaryAdapter<IMovingObject>.Create(dict, NoStrategies, []);
+
+        Assert.Throws<NotSupportedException>(() => adapter.Velocity);
     }
 }

--- a/SpaceBattle.Lib.Tests/RegisterAdapterDependencyTests.cs
+++ b/SpaceBattle.Lib.Tests/RegisterAdapterDependencyTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Hwdtech;
+using Hwdtech.Ioc;
+using StarWars.Lib;
+using Xunit;
+
+[assembly: StarWars.Lib.Adapter(
+    typeof(StarWars.Tests.IMovingObject),
+    "Velocity",
+    typeof(StarWars.Tests.TestVelocityResolver))]
+
+namespace StarWars.Tests;
+
+public static class TestVelocityResolver
+{
+    public static object Resolve(IDictionary<string, object> dict) => dict["vel"];
+}
+
+public class RegisterAdapterDependencyTests
+{
+    public RegisterAdapterDependencyTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var scope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", scope).Execute();
+        new InitScopeBasedIoCImplementationCommand().Execute();
+    }
+
+    [Fact]
+    public void Execute_RegistersAdapterInIoC()
+    {
+        new RegisterAdapterDependency<IMovingObject>(Assembly.GetExecutingAssembly()).Execute();
+
+        var dict = new Dictionary<string, object>
+        {
+            ["Location"] = new Vector([1, 2]),
+            ["vel"] = new Vector([3, 4])
+        };
+
+        var adapter = IoC.Resolve<IMovingObject>("Adapters.IMovingObject", dict);
+
+        Assert.NotNull(adapter);
+        Assert.IsAssignableFrom<IMovingObject>(adapter);
+    }
+
+    [Fact]
+    public void Execute_AdapterReadsLocationFromDictionary()
+    {
+        new RegisterAdapterDependency<IMovingObject>(Assembly.GetExecutingAssembly()).Execute();
+
+        var location = new Vector([7, 8]);
+        var dict = new Dictionary<string, object> { ["Location"] = location, ["vel"] = new Vector([0, 0]) };
+
+        var adapter = IoC.Resolve<IMovingObject>("Adapters.IMovingObject", dict);
+
+        Assert.Equal(location, adapter.Location);
+    }
+
+    [Fact]
+    public void Execute_AdapterUsesCustomStrategyForVelocity()
+    {
+        new RegisterAdapterDependency<IMovingObject>(Assembly.GetExecutingAssembly()).Execute();
+
+        var velocity = new Vector([5, 6]);
+        var dict = new Dictionary<string, object> { ["Location"] = new Vector([0, 0]), ["vel"] = velocity };
+
+        var adapter = IoC.Resolve<IMovingObject>("Adapters.IMovingObject", dict);
+
+        Assert.Equal(velocity, adapter.Velocity);
+    }
+}

--- a/SpaceBattle.Lib.Tests/RegisterAdapterDependencyTests.cs
+++ b/SpaceBattle.Lib.Tests/RegisterAdapterDependencyTests.cs
@@ -19,6 +19,9 @@ public static class TestVelocityResolver
 
 public class RegisterAdapterDependencyTests
 {
+    private readonly IReadOnlyList<IMethodHandler> _handlers =
+        [new GetterMethodHandler(), new SetterMethodHandler()];
+
     public RegisterAdapterDependencyTests()
     {
         new InitScopeBasedIoCImplementationCommand().Execute();
@@ -27,10 +30,17 @@ public class RegisterAdapterDependencyTests
         new InitScopeBasedIoCImplementationCommand().Execute();
     }
 
+    private RegisterAdapterDependency<IMovingObject> BuildCommand()
+    {
+        var strategies = new AdapterStrategyReader<IMovingObject>(Assembly.GetExecutingAssembly()).Read();
+        var factory = new DictionaryAdapterFactory<IMovingObject>(_handlers);
+        return new RegisterAdapterDependency<IMovingObject>(factory, strategies);
+    }
+
     [Fact]
     public void Execute_RegistersAdapterInIoC()
     {
-        new RegisterAdapterDependency<IMovingObject>(Assembly.GetExecutingAssembly()).Execute();
+        BuildCommand().Execute();
 
         var dict = new Dictionary<string, object>
         {
@@ -47,7 +57,7 @@ public class RegisterAdapterDependencyTests
     [Fact]
     public void Execute_AdapterReadsLocationFromDictionary()
     {
-        new RegisterAdapterDependency<IMovingObject>(Assembly.GetExecutingAssembly()).Execute();
+        BuildCommand().Execute();
 
         var location = new Vector([7, 8]);
         var dict = new Dictionary<string, object> { ["Location"] = location, ["vel"] = new Vector([0, 0]) };
@@ -60,7 +70,7 @@ public class RegisterAdapterDependencyTests
     [Fact]
     public void Execute_AdapterUsesCustomStrategyForVelocity()
     {
-        new RegisterAdapterDependency<IMovingObject>(Assembly.GetExecutingAssembly()).Execute();
+        BuildCommand().Execute();
 
         var velocity = new Vector([5, 6]);
         var dict = new Dictionary<string, object> { ["Location"] = new Vector([0, 0]), ["vel"] = velocity };

--- a/SpaceBattle.Lib/AdapterAttribute.cs
+++ b/SpaceBattle.Lib/AdapterAttribute.cs
@@ -1,0 +1,16 @@
+﻿namespace StarWars.Lib;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class AdapterAttribute : Attribute
+{
+    public Type InterfaceType { get; }
+    public string PropertyName { get; }
+    public Type ResolverType { get; }
+
+    public AdapterAttribute(Type interfaceType, string propertyName, Type resolverType)
+    {
+        InterfaceType = interfaceType;
+        PropertyName = propertyName;
+        ResolverType = resolverType;
+    }
+}

--- a/SpaceBattle.Lib/AdapterStrategyReader.cs
+++ b/SpaceBattle.Lib/AdapterStrategyReader.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+
+namespace StarWars.Lib;
+
+public class AdapterStrategyReader<T> where T : class
+{
+    private readonly Assembly _assembly;
+
+    public AdapterStrategyReader(Assembly assembly)
+    {
+        _assembly = assembly;
+    }
+
+    public IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> Read()
+        => _assembly
+            .GetCustomAttributes<AdapterAttribute>()
+            .Where(a => a.InterfaceType == typeof(T))
+            .ToDictionary(
+                a => a.PropertyName,
+                a => (Func<IDictionary<string, object>, object>)
+                    a.ResolverType
+                        .GetMethod("Resolve", BindingFlags.Public | BindingFlags.Static)!
+                        .CreateDelegate(typeof(Func<IDictionary<string, object>, object>))
+            );
+}

--- a/SpaceBattle.Lib/DictionaryAdapter.cs
+++ b/SpaceBattle.Lib/DictionaryAdapter.cs
@@ -6,38 +6,29 @@ public class DictionaryAdapter<T> : DispatchProxy where T : class
 {
     private IDictionary<string, object> _dictionary = null!;
     private IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> _strategies = null!;
+    private IReadOnlyList<IMethodHandler> _handlers = null!;
 
     public static T Create(
         IDictionary<string, object> dictionary,
-        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies)
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies,
+        IReadOnlyList<IMethodHandler> handlers)
     {
         var proxy = Create<T, DictionaryAdapter<T>>() as DictionaryAdapter<T>;
         proxy!._dictionary = dictionary;
         proxy._strategies = strategies;
+        proxy._handlers = handlers;
         return (T)(object)proxy;
     }
 
     protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
     {
         var name = targetMethod!.Name;
-
-        if (name.StartsWith("get_"))
+        var handler = _handlers.FirstOrDefault(h => h.CanHandle(name));
+        if (handler is not null)
         {
-            var prop = name[4..];
-            if (_strategies.TryGetValue(prop, out var strategy))
-            {
-                return strategy(_dictionary);
-            }
-
-            return _dictionary[prop];
+            return handler.Handle(name, _dictionary, _strategies, args);
         }
 
-        if (name.StartsWith("set_"))
-        {
-            _dictionary[name[4..]] = args![0]!;
-            return null;
-        }
-
-        throw new NotSupportedException($"Method '{name}' is not supported by DictionaryAdapter.");
+        throw new NotSupportedException($"No handler registered for method '{name}'.");
     }
 }

--- a/SpaceBattle.Lib/DictionaryAdapter.cs
+++ b/SpaceBattle.Lib/DictionaryAdapter.cs
@@ -1,0 +1,43 @@
+﻿using System.Reflection;
+
+namespace StarWars.Lib;
+
+public class DictionaryAdapter<T> : DispatchProxy where T : class
+{
+    private IDictionary<string, object> _dictionary = null!;
+    private IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> _strategies = null!;
+
+    public static T Create(
+        IDictionary<string, object> dictionary,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies)
+    {
+        var proxy = Create<T, DictionaryAdapter<T>>() as DictionaryAdapter<T>;
+        proxy!._dictionary = dictionary;
+        proxy._strategies = strategies;
+        return (T)(object)proxy;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        var name = targetMethod!.Name;
+
+        if (name.StartsWith("get_"))
+        {
+            var prop = name[4..];
+            if (_strategies.TryGetValue(prop, out var strategy))
+            {
+                return strategy(_dictionary);
+            }
+
+            return _dictionary[prop];
+        }
+
+        if (name.StartsWith("set_"))
+        {
+            _dictionary[name[4..]] = args![0]!;
+            return null;
+        }
+
+        throw new NotSupportedException($"Method '{name}' is not supported by DictionaryAdapter.");
+    }
+}

--- a/SpaceBattle.Lib/DictionaryAdapterFactory.cs
+++ b/SpaceBattle.Lib/DictionaryAdapterFactory.cs
@@ -1,0 +1,16 @@
+﻿namespace StarWars.Lib;
+
+public class DictionaryAdapterFactory<T> : IAdapterFactory<T> where T : class
+{
+    private readonly IReadOnlyList<IMethodHandler> _handlers;
+
+    public DictionaryAdapterFactory(IReadOnlyList<IMethodHandler> handlers)
+    {
+        _handlers = handlers;
+    }
+
+    public T Create(
+        IDictionary<string, object> dictionary,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies)
+        => DictionaryAdapter<T>.Create(dictionary, strategies, _handlers);
+}

--- a/SpaceBattle.Lib/GetterMethodHandler.cs
+++ b/SpaceBattle.Lib/GetterMethodHandler.cs
@@ -1,0 +1,21 @@
+﻿namespace StarWars.Lib;
+
+public class GetterMethodHandler : IMethodHandler
+{
+    public bool CanHandle(string methodName) => methodName.StartsWith("get_");
+
+    public object? Handle(
+        string methodName,
+        IDictionary<string, object> dictionary,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies,
+        object?[]? args)
+    {
+        var prop = methodName[4..];
+        if (strategies.TryGetValue(prop, out var strategy))
+        {
+            return strategy(dictionary);
+        }
+
+        return dictionary[prop];
+    }
+}

--- a/SpaceBattle.Lib/IAdapterFactory.cs
+++ b/SpaceBattle.Lib/IAdapterFactory.cs
@@ -1,0 +1,8 @@
+﻿namespace StarWars.Lib;
+
+public interface IAdapterFactory<T> where T : class
+{
+    T Create(
+        IDictionary<string, object> dictionary,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies);
+}

--- a/SpaceBattle.Lib/IMethodHandler.cs
+++ b/SpaceBattle.Lib/IMethodHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace StarWars.Lib;
+
+public interface IMethodHandler
+{
+    bool CanHandle(string methodName);
+
+    object? Handle(
+        string methodName,
+        IDictionary<string, object> dictionary,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies,
+        object?[]? args);
+}

--- a/SpaceBattle.Lib/RegisterAdapterDependency.cs
+++ b/SpaceBattle.Lib/RegisterAdapterDependency.cs
@@ -1,37 +1,29 @@
-﻿using System.Reflection;
-using Hwdtech;
+﻿using Hwdtech;
 
 namespace StarWars.Lib;
 
 public class RegisterAdapterDependency<T> : ICommand where T : class
 {
-    private readonly Assembly _assembly;
+    private readonly IAdapterFactory<T> _factory;
+    private readonly IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> _strategies;
 
-    public RegisterAdapterDependency(Assembly assembly)
+    public RegisterAdapterDependency(
+        IAdapterFactory<T> factory,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies)
     {
-        _assembly = assembly;
+        _factory = factory;
+        _strategies = strategies;
     }
 
     public void Execute()
     {
-        var strategies = _assembly
-            .GetCustomAttributes<AdapterAttribute>()
-            .Where(a => a.InterfaceType == typeof(T))
-            .ToDictionary(
-                a => a.PropertyName,
-                a => (Func<IDictionary<string, object>, object>)
-                    a.ResolverType
-                        .GetMethod("Resolve", BindingFlags.Public | BindingFlags.Static)!
-                        .CreateDelegate(typeof(Func<IDictionary<string, object>, object>))
-            );
-
         IoC.Resolve<Hwdtech.ICommand>(
             "IoC.Register",
             $"Adapters.{typeof(T).Name}",
             (Func<object, object>)(obj =>
-                DictionaryAdapter<T>.Create(
+                _factory.Create(
                     (IDictionary<string, object>)((object[])obj)[0],
-                    strategies
+                    _strategies
                 )
             )
         ).Execute();

--- a/SpaceBattle.Lib/RegisterAdapterDependency.cs
+++ b/SpaceBattle.Lib/RegisterAdapterDependency.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using Hwdtech;
+
+namespace StarWars.Lib;
+
+public class RegisterAdapterDependency<T> : ICommand where T : class
+{
+    private readonly Assembly _assembly;
+
+    public RegisterAdapterDependency(Assembly assembly)
+    {
+        _assembly = assembly;
+    }
+
+    public void Execute()
+    {
+        var strategies = _assembly
+            .GetCustomAttributes<AdapterAttribute>()
+            .Where(a => a.InterfaceType == typeof(T))
+            .ToDictionary(
+                a => a.PropertyName,
+                a => (Func<IDictionary<string, object>, object>)
+                    a.ResolverType
+                        .GetMethod("Resolve", BindingFlags.Public | BindingFlags.Static)!
+                        .CreateDelegate(typeof(Func<IDictionary<string, object>, object>))
+            );
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            $"Adapters.{typeof(T).Name}",
+            (Func<object, object>)(obj =>
+                DictionaryAdapter<T>.Create(
+                    (IDictionary<string, object>)((object[])obj)[0],
+                    strategies
+                )
+            )
+        ).Execute();
+    }
+}

--- a/SpaceBattle.Lib/SetterMethodHandler.cs
+++ b/SpaceBattle.Lib/SetterMethodHandler.cs
@@ -1,0 +1,16 @@
+﻿namespace StarWars.Lib;
+
+public class SetterMethodHandler : IMethodHandler
+{
+    public bool CanHandle(string methodName) => methodName.StartsWith("set_");
+
+    public object? Handle(
+        string methodName,
+        IDictionary<string, object> dictionary,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object>, object>> strategies,
+        object?[]? args)
+    {
+        dictionary[methodName[4..]] = args![0]!;
+        return null;
+    }
+}


### PR DESCRIPTION
Реализовать команду RegisterAdapterDependency<T>, которая:
1. Читает [Adapter]-атрибуты из сборки для типа T
2. Строит словарь стратегий
3. Регистрирует в IoC фабрику под ключом "Adapters.<InterfaceName>"

После выполнения становится доступен вызов:
IoC.Resolve<IMovingObject>("Adapters.IMovingObject", dict)